### PR TITLE
[PP-45] Admin role of new users

### DIFF
--- a/src/components/User/User.module.scss
+++ b/src/components/User/User.module.scss
@@ -83,3 +83,13 @@ $size-admin: 2rem;
     transform: scale(0.9);
   }
 }
+
+.approve__btn {
+  padding: 0.5rem;
+  height: auto;
+  font-size: 1.2rem;
+
+  &_disabled {
+    display: none;
+  }
+}

--- a/src/components/User/User.tsx
+++ b/src/components/User/User.tsx
@@ -1,12 +1,13 @@
 import React, { FC } from 'react';
 import classNames from 'classnames';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import styles from './User.module.scss';
 import { CardNest, PrimaryButton } from '@/components';
-import { IUser } from '@/utils/interfaces';
+import { IUser, IUserFromBE } from '@/utils/interfaces';
 import { roomStateSelectors, userSelectors } from '@/store/selectors';
 import { socketService } from '@/services';
 import { SocketEvent } from '@/utils/enums';
+import { userActions } from '@/store/actions';
 
 interface IUserProps {
   user: IUser
@@ -16,6 +17,11 @@ export const User: FC<IUserProps> = ({ user }) => {
   const { role } = user;
   const clientRole = useSelector(userSelectors.role);
   const roomId = useSelector(roomStateSelectors.roomId);
+  const dispatch = useDispatch();
+
+  const updateUserRole = () => {
+    dispatch(userActions.addRole('member'));
+  };
 
   const approveUser = () => {
     const updatedUser = {
@@ -24,6 +30,7 @@ export const User: FC<IUserProps> = ({ user }) => {
       role: 'member',
     };
     socketService.emit(SocketEvent.UserAddRole, updatedUser);
+    socketService.on(SocketEvent.UserAddRole, updateUserRole);
   };
 
   return (

--- a/src/components/User/User.tsx
+++ b/src/components/User/User.tsx
@@ -1,8 +1,12 @@
 import React, { FC } from 'react';
 import classNames from 'classnames';
+import { useSelector } from 'react-redux';
 import styles from './User.module.scss';
-import { CardNest } from '@/components';
+import { CardNest, PrimaryButton } from '@/components';
 import { IUser } from '@/utils/interfaces';
+import { roomStateSelectors, userSelectors } from '@/store/selectors';
+import { socketService } from '@/services';
+import { SocketEvent } from '@/utils/enums';
 
 interface IUserProps {
   user: IUser
@@ -10,6 +14,17 @@ interface IUserProps {
 
 export const User: FC<IUserProps> = ({ user }) => {
   const { role } = user;
+  const clientRole = useSelector(userSelectors.role);
+  const roomId = useSelector(roomStateSelectors.roomId);
+
+  const approveUser = () => {
+    const updatedUser = {
+      userId: user.userId,
+      roomId,
+      role: 'member',
+    };
+    socketService.emit(SocketEvent.UserAddRole, updatedUser);
+  };
 
   return (
     <li className={styles.item}>
@@ -24,6 +39,17 @@ export const User: FC<IUserProps> = ({ user }) => {
         <div className={styles.name}>
           {user.name}
         </div>
+        <PrimaryButton
+          onClick={approveUser}
+          className={classNames(
+            styles.approve__btn,
+            {
+              [styles.approve__btn_disabled]: clientRole !== 'admin' || role === 'member',
+            },
+          )}
+        >
+          Approve
+        </PrimaryButton>
         <div className={styles.kick} />
       </div>
       <CardNest

--- a/src/components/User/User.tsx
+++ b/src/components/User/User.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import { useDispatch, useSelector } from 'react-redux';
 import styles from './User.module.scss';
 import { CardNest, PrimaryButton } from '@/components';
-import { IUser, IUserFromBE } from '@/utils/interfaces';
+import { IUser } from '@/utils/interfaces';
 import { roomStateSelectors, userSelectors } from '@/store/selectors';
 import { socketService } from '@/services';
 import { SocketEvent } from '@/utils/enums';

--- a/src/pages/Game/Game.tsx
+++ b/src/pages/Game/Game.tsx
@@ -41,7 +41,7 @@ export const Game: React.FC = () => {
 
   return (
     <main className={styles.main}>
-      {role ? (
+      {role !== 'spectator' ? (
         <>
           <section className={styles.leftSection}>
             <PanelUsers />

--- a/src/pages/Game/Game.tsx
+++ b/src/pages/Game/Game.tsx
@@ -21,6 +21,7 @@ export const Game: React.FC = () => {
   const title = useSelector(roomStateSelectors.roomTitle);
   const userId = useSelector(userSelectors.userId);
   const roomId = useSelector(roomStateSelectors.roomId);
+  const role = useSelector(userSelectors.role);
   const dispatch = useAppDispatch();
 
   useEffect(() => {
@@ -40,31 +41,44 @@ export const Game: React.FC = () => {
 
   return (
     <main className={styles.main}>
-      <section className={styles.leftSection}>
-        <PanelUsers />
-        <Chat />
-      </section>
-      <article className={styles.wrapper}>
-        <section>
-          <h1 className={styles.title}>{title}</h1>
-          <Controls />
-        </section>
-        <CommonArea
-          isCardOpened={isCardOpened}
-          selectedCardValue={selectedCardValue}
-          setIsCardIsVisible={setIsCardIsVisible}
-          setSelectedCardValue={setSelectedCardValue}
-        />
-        <PanelVoteCards
-          setSelectedCardValue={setSelectedCardValue}
-          selectedCardValue={selectedCardValue}
-          isCardOpened={isCardOpened}
-        />
-      </article>
-      <section className={styles.rightSection}>
-        <ProfileInfo />
-        <Issues />
-      </section>
+      {role ? (
+        <>
+          <section className={styles.leftSection}>
+            <PanelUsers />
+            <Chat />
+          </section>
+          <article className={styles.wrapper}>
+            <section>
+              <h1 className={styles.title}>{title}</h1>
+              <Controls />
+            </section>
+            <CommonArea
+              isCardOpened={isCardOpened}
+              selectedCardValue={selectedCardValue}
+              setIsCardIsVisible={setIsCardIsVisible}
+              setSelectedCardValue={setSelectedCardValue}
+            />
+            <PanelVoteCards
+              setSelectedCardValue={setSelectedCardValue}
+              selectedCardValue={selectedCardValue}
+              isCardOpened={isCardOpened}
+            />
+          </article>
+          <section className={styles.rightSection}>
+            <ProfileInfo />
+            <Issues />
+          </section>
+        </>
+      ) : (
+        <>
+          <section className={styles.leftSection}>
+            <Chat />
+          </section>
+          <section className={styles.rightSection}>
+            <ProfileInfo />
+          </section>
+        </>
+      )}
     </main>
   );
 };

--- a/src/utils/enums/SocketEvent.ts
+++ b/src/utils/enums/SocketEvent.ts
@@ -1,5 +1,6 @@
 export enum SocketEvent {
   UserVote = 'user_vote',
+  UserAddRole = 'user_add_role',
   TaskCreate = 'task_create',
   TaskDelete = 'task_delete',
   TaskUpdateScore = 'task_set_score',


### PR DESCRIPTION
Task: https://andrei-lysiuk.atlassian.net/browse/PP-45
Description:
- user should see only chat when he has no role in room 
- admin could add user role for new users that joined the room(new users will not have role)

Task complete on feature/PP-48-check-user-vote-through-the-game-progress